### PR TITLE
Refactor: propagate errors in typed_ast

### DIFF
--- a/src/gig/compiler.gleam
+++ b/src/gig/compiler.gleam
@@ -5,6 +5,7 @@ import gig/headers
 import gig/mono
 import gig/patch
 import gig/typed_ast
+import gleam/bit_array
 import gleam/dict
 import gleam/set
 import listx
@@ -311,9 +312,10 @@ fn infer_file(
 
   // infer this file
   io.println("Check " <> source)
-  let assert Ok(c) = typed_ast.infer_module(c, module, module_id, source_text)
-
-  #(c, done)
+  case typed_ast.infer_module(c, module, module_id, source_text) {
+    Ok(c) -> #(c, done)
+    Error(err) -> panic as error(source, err.span, typed_ast.inspect_error(err))
+  }
 }
 
 fn parse_module(file: String, input: String) {
@@ -336,4 +338,48 @@ fn parse_module(file: String, input: String) {
           )
       }
   }
+}
+
+fn error(source: String, span: typed_ast.Span, message: String) -> String {
+  let start = span.start
+  let end = span.end
+
+  let context_before = case start {
+    start if start < 100 -> string.slice(source, 0, start)
+    start -> string.slice(source, start - 100, 100)
+  }
+  let context_before = string.split(context_before, "\n")
+  let context_before =
+    context_before
+    |> list.drop(list.length(context_before) - 3)
+    |> list.drop_while(fn(x) { x == "" })
+    |> string.join("\n")
+
+  let context_after =
+    source
+    |> string.slice(end, 100)
+    |> string.split("\n")
+    |> list.take(3)
+    |> string.join("\n")
+
+  let error_part = string.slice(source, start, end - start)
+
+  // TODO this unicode escape sequence is not valid in c, needs compilation
+  // let escape = "\u{001b}["
+  let assert Ok(escape) = bit_array.to_string(<<27, 91>>)
+  let clear = escape <> "0m"
+  let red_underline = escape <> "4;31m"
+
+  "Error: "
+  <> message
+  // <> "\n\nat: "
+  // <> c.current_module
+  // <> "."
+  // <> c.current_definition
+  <> "\n\n"
+  <> context_before
+  <> red_underline
+  <> error_part
+  <> clear
+  <> context_after
 }

--- a/src/gig/compiler.gleam
+++ b/src/gig/compiler.gleam
@@ -314,7 +314,8 @@ fn infer_file(
   io.println("Check " <> source)
   case typed_ast.infer_module(c, module, module_id, source_text) {
     Ok(c) -> #(c, done)
-    Error(err) -> panic as error(source, err.span, typed_ast.inspect_error(err))
+    Error(err) ->
+      panic as error(source, err.location, typed_ast.inspect_error(err))
   }
 }
 
@@ -340,9 +341,13 @@ fn parse_module(file: String, input: String) {
   }
 }
 
-fn error(source: String, span: typed_ast.Span, message: String) -> String {
-  let start = span.start
-  let end = span.end
+fn error(
+  source: String,
+  location: typed_ast.Location,
+  message: String,
+) -> String {
+  let start = location.span.start
+  let end = location.span.end
 
   let context_before = case start {
     start if start < 100 -> string.slice(source, 0, start)
@@ -372,10 +377,10 @@ fn error(source: String, span: typed_ast.Span, message: String) -> String {
 
   "Error: "
   <> message
-  // <> "\n\nat: "
-  // <> c.current_module
-  // <> "."
-  // <> c.current_definition
+  <> "\n\nat: "
+  <> location.module
+  <> "."
+  <> location.definition
   <> "\n\n"
   <> context_before
   <> red_underline

--- a/src/gig/compiler.gleam
+++ b/src/gig/compiler.gleam
@@ -107,7 +107,8 @@ pub fn compile(gleam_file_name: String, options: CompileOptions) {
   let assert Ok(source_text) = read_source(sources, "gleam")
   let assert Ok(prelude) = glance.module(source_text)
   let typed = typed_ast.new_context()
-  let typed = typed_ast.infer_module(typed, prelude, "gleam", source_text)
+  let assert Ok(typed) =
+    typed_ast.infer_module(typed, prelude, "gleam", source_text)
 
   // parse and typecheck input (recursively)
   let #(typed, _done) = infer_file(sources, typed, ["gleam"], module_id)
@@ -310,7 +311,7 @@ fn infer_file(
 
   // infer this file
   io.println("Check " <> source)
-  let c = typed_ast.infer_module(c, module, module_id, source_text)
+  let assert Ok(c) = typed_ast.infer_module(c, module, module_id, source_text)
 
   #(c, done)
 }

--- a/src/gig/compiler.gleam
+++ b/src/gig/compiler.gleam
@@ -315,7 +315,7 @@ fn infer_file(
   case typed_ast.infer_module(c, module, module_id, source_text) {
     Ok(c) -> #(c, done)
     Error(err) ->
-      panic as error(source, err.location, typed_ast.inspect_error(err))
+      panic as error(source_text, err.location, typed_ast.inspect_error(err))
   }
 }
 

--- a/src/gig/typed_ast.gleam
+++ b/src/gig/typed_ast.gleam
@@ -1927,6 +1927,7 @@ fn infer_expression(
           #(c, [result, ..fields])
         }),
       )
+      let ordered_fields = list.reverse(ordered_fields)
 
       // The result type is the same as the constructor type
       let typ = constructor_ret


### PR DESCRIPTION
For issue #6.

This PR replaces most instances of `let assert` and `panic` with explicit `Result(a, Error)` returns. There are two issues of code style that I noticed halfway through and I've adjusted parts of the code I touched to the style I started out with, but let me know if you'd like them changed to the alternative:

 1. I prefer to qualify `result.try` - this feels more natural/readable to me.
 2. I'm used to using `result.map` when it makes sense. You seem to typically use `result.try` and return an explicit `Ok(thing)` at the end. I see advantages to the latter style, in particular during refactoring and in longer code blocks.