### PR TITLE
Per module inference context + substitute type variables

### DIFF
--- a/patch/gleam/bit_array.patch.gleam
+++ b/patch/gleam/bit_array.patch.gleam
@@ -7,7 +7,7 @@ fn unsafe_to_string(a: BitArray) -> String {
 }
 
 @external(c, "", "gleam_bit_array_from_string")
-fn from_string(x: String) -> BitArray
+pub fn from_string(x: String) -> BitArray
 
 fn is_utf8_loop(bits: BitArray) -> Bool {
   case bits {

--- a/patch/gleam/io.patch.gleam
+++ b/patch/gleam/io.patch.gleam
@@ -27,7 +27,7 @@ pub fn println(string: String) -> Nil {
     do_print("\n")
 }
 
-fn println_error(string: String) -> Nil {
+pub fn println_error(string: String) -> Nil {
   do_print_error(string)
   do_print_error("\n")
 }

--- a/patch/gleam/string.patch.gleam
+++ b/patch/gleam/string.patch.gleam
@@ -74,7 +74,7 @@ fn append_pairs(strings: List(String)) {
 fn unsafe_int_to_utf_codepoint(a: Int) -> UtfCodepoint
 
 @external(c, "", "gleam_string_from_utf_codepoints")
-fn from_utf_codepoints(utf_codepoints: List(UtfCodepoint)) -> String
+pub fn from_utf_codepoints(utf_codepoints: List(UtfCodepoint)) -> String
 
 @external(c, "", "gleam_string_do_to_utf_codepoints")
 fn do_to_utf_codepoints(string: String) -> List(UtfCodepoint)

--- a/src/gig/compiler.gleam
+++ b/src/gig/compiler.gleam
@@ -107,8 +107,8 @@ pub fn compile(gleam_file_name: String, options: CompileOptions) {
   // process the prelude
   let assert Ok(source_text) = read_source(sources, "gleam")
   let assert Ok(prelude) = glance.module(source_text)
-  let typed = typed_ast.new_context()
-  let assert Ok(typed) = typed_ast.infer_module(typed, prelude, "gleam")
+  let modules = dict.new()
+  let assert Ok(typed) = typed_ast.infer_module(modules, prelude, "gleam")
 
   // parse and typecheck input (recursively)
   let #(typed, _done) = infer_file(sources, typed, ["gleam"], module_id)
@@ -311,7 +311,7 @@ fn infer_file(
 
   // infer this file
   io.println("Check " <> source)
-  case typed_ast.infer_module(c, module, module_id) {
+  case typed_ast.infer_module(c.modules, module, module_id) {
     Ok(c) -> #(c, done)
     Error(err) ->
       panic as error(source_text, err.location, typed_ast.inspect_error(err))

--- a/src/gig/compiler.gleam
+++ b/src/gig/compiler.gleam
@@ -108,8 +108,7 @@ pub fn compile(gleam_file_name: String, options: CompileOptions) {
   let assert Ok(source_text) = read_source(sources, "gleam")
   let assert Ok(prelude) = glance.module(source_text)
   let typed = typed_ast.new_context()
-  let assert Ok(typed) =
-    typed_ast.infer_module(typed, prelude, "gleam", source_text)
+  let assert Ok(typed) = typed_ast.infer_module(typed, prelude, "gleam")
 
   // parse and typecheck input (recursively)
   let #(typed, _done) = infer_file(sources, typed, ["gleam"], module_id)
@@ -312,7 +311,7 @@ fn infer_file(
 
   // infer this file
   io.println("Check " <> source)
-  case typed_ast.infer_module(c, module, module_id, source_text) {
+  case typed_ast.infer_module(c, module, module_id) {
     Ok(c) -> #(c, done)
     Error(err) ->
       panic as error(source_text, err.location, typed_ast.inspect_error(err))

--- a/src/gig/compiler.gleam
+++ b/src/gig/compiler.gleam
@@ -7,7 +7,6 @@ import gig/patch
 import gig/typed_ast
 import gleam/bit_array
 import gleam/dict
-import gleam/pair
 import gleam/set
 import listx
 

--- a/src/gig/core.gleam
+++ b/src/gig/core.gleam
@@ -14,14 +14,17 @@ import gleam/option.{None, Some}
 
 pub const builtin = t.builtin
 
+pub type TypeVarId =
+  t.TypeVarId
+
 pub type Type {
   NamedType(id: String, parameters: List(Type))
   FunctionType(parameters: List(Type), return: Type)
-  Unbound(id: Int)
+  Unbound(id: TypeVarId)
 }
 
 pub type Poly {
-  Poly(vars: List(Int), typ: Type)
+  Poly(vars: List(TypeVarId), typ: Type)
 }
 
 pub type Parameter {
@@ -1633,7 +1636,7 @@ fn map_poly(c: t.Context, typ: t.Poly) {
 
 fn register_tuple(c: Context, size: Int) {
   let id = gen_names.get_tuple_id(size)
-  let vars = listx.sane_range(size)
+  let vars = list.map(listx.sane_range(size), t.TypeVarId("", _))
   let element_types = list.map(vars, fn(i) { Unbound(i) })
   let custom_typ = Poly(vars, NamedType(id, element_types))
   let constructor_typ = Poly(vars, FunctionType(element_types, custom_typ.typ))

--- a/src/gig/core.gleam
+++ b/src/gig/core.gleam
@@ -1636,7 +1636,7 @@ fn map_poly(typ: t.Poly) {
 
 fn register_tuple(c: Module, size: Int) {
   let id = gen_names.get_tuple_id(size)
-  let vars = list.map(listx.sane_range(size), t.TypeVarId("", _))
+  let vars = list.map(listx.sane_range(size), t.TypeVarId)
   let element_types = list.map(vars, fn(i) { Unbound(i) })
   let custom_typ = Poly(vars, NamedType(id, element_types))
   let constructor_typ = Poly(vars, FunctionType(element_types, custom_typ.typ))

--- a/src/gig/core.gleam
+++ b/src/gig/core.gleam
@@ -1204,9 +1204,16 @@ fn lower_expression(c: Context, exp: t.Expression) -> Exp {
         }
       }
     }
-    t.Constant(value:, ..) -> {
+    t.Constant(module:, name:, ..) -> {
+      // TODO: in order for lowering to not require implementation details of
+      // other modules, inlining must happen later
+      let assert Ok(mod) = dict.get(c.modules, module)
+      let assert Ok(constant) =
+        list.find(mod.constants, fn(constant) {
+          constant.definition.name == name
+        })
       // inline the constant
-      lower_expression(c, value)
+      lower_expression(c, constant.definition.value)
     }
     t.NegateInt(typ, value) -> {
       let typ = map_type(typ)

--- a/src/gig/core.gleam
+++ b/src/gig/core.gleam
@@ -1662,7 +1662,7 @@ fn register_tuple(c: Module, size: Int) {
 
 fn map_type(typ: t.Type) {
   case typ {
-    t.NamedType(name:, module:, parameters:) -> {
+    t.NamedType(module:, name:, parameters:) -> {
       let parameters = list.map(parameters, map_type)
       NamedType(get_id(module, name), parameters)
     }

--- a/src/gig/core.gleam
+++ b/src/gig/core.gleam
@@ -146,7 +146,7 @@ fn lower_module(acc: Module, modules, module: t.Module) {
       let external =
         list.find(attrs, fn(x) {
           case x {
-            t.Attribute("external", [t.LocalVariable(_, "c"), ..]) -> True
+            t.Attribute("external", [t.NameAttributeArgument("c"), ..]) -> True
             _ -> False
           }
         })
@@ -156,9 +156,9 @@ fn lower_module(acc: Module, modules, module: t.Module) {
           let assert t.Attribute(
             _,
             [
-              t.LocalVariable(_, "c"),
-              t.String(_, _src),
-              t.String(_, external_name),
+              t.NameAttributeArgument("c"),
+              t.StringAttributeArgument(_src),
+              t.StringAttributeArgument(external_name),
             ],
           ) = external
           let fun = fun.definition

--- a/src/gig/headers.gleam
+++ b/src/gig/headers.gleam
@@ -6,7 +6,7 @@ import gleam/dict
 import gleam/list
 import gleam/string
 
-pub fn module_headers(c: core.Context) {
+pub fn module_headers(c: core.Module) {
   c.externals
   |> list.filter(fn(x) { !x.builtin })
   |> list.group(fn(x) { x.module })

--- a/src/gig/mono.gleam
+++ b/src/gig/mono.gleam
@@ -87,7 +87,7 @@ pub type Exp {
   Panic(typ: Type, value: Exp)
 }
 
-pub fn init_context(in: t.Context) -> Context {
+pub fn init_context(in: t.Module) -> Context {
   let in_types =
     list.fold(in.types, dict.new(), fn(d, i) { dict.insert(d, i.id, i) })
   let in_functions =
@@ -111,7 +111,7 @@ pub fn init_context(in: t.Context) -> Context {
   )
 }
 
-pub fn run(in: t.Context, main_name: String) {
+pub fn run(in: t.Module, main_name: String) {
   let c = init_context(in)
 
   let main = case dict.get(c.in_functions, main_name) {

--- a/src/gig/mono.gleam
+++ b/src/gig/mono.gleam
@@ -137,7 +137,7 @@ pub fn run(in: t.Context, main_name: String) {
   #(c, main_name)
 }
 
-pub fn sub_type(sub: List(#(Int, Type)), typ: t.Type) -> Type {
+pub fn sub_type(sub: List(#(t.TypeVarId, Type)), typ: t.Type) -> Type {
   case typ {
     t.Unbound(id) ->
       case list.find(sub, fn(sub) { sub.0 == id }) {
@@ -150,7 +150,11 @@ pub fn sub_type(sub: List(#(Int, Type)), typ: t.Type) -> Type {
   }
 }
 
-fn unify_poly(c: Context, poly: t.Poly, mono: Type) -> List(#(Int, Type)) {
+fn unify_poly(
+  c: Context,
+  poly: t.Poly,
+  mono: Type,
+) -> List(#(t.TypeVarId, Type)) {
   let sub = unify_type(c, poly.typ, mono)
   list.map(poly.vars, fn(x) {
     case list.find(sub, fn(s) { s.0 == x }) {
@@ -162,7 +166,11 @@ fn unify_poly(c: Context, poly: t.Poly, mono: Type) -> List(#(Int, Type)) {
   })
 }
 
-fn unify_type(c: Context, poly: t.Type, mono: Type) -> List(#(Int, Type)) {
+fn unify_type(
+  c: Context,
+  poly: t.Type,
+  mono: Type,
+) -> List(#(t.TypeVarId, Type)) {
   case poly, mono {
     t.Unbound(id), _ -> [#(id, mono)]
     t.NamedType(a, aa), NamedType(b, ba) ->
@@ -194,7 +202,7 @@ pub fn type_name(typ: Type) -> String {
   }
 }
 
-fn get_type_string(sub: List(#(Int, Type))) {
+fn get_type_string(sub: List(#(t.TypeVarId, Type))) {
   // TODO only include typed that are actually used
   // e.g. variant that only uses part of the params
   // e.g. phantom type
@@ -410,7 +418,7 @@ fn instantiate_builtin(c: Context, fun_name: String, mono: Type) -> Context {
 
 fn typed_to_mono_exp(
   c: Context,
-  sub: List(#(Int, Type)),
+  sub: List(#(t.TypeVarId, Type)),
   e: t.Exp,
 ) -> #(Context, Exp) {
   let c = instantiate_type(c, sub_type(sub, e.typ))

--- a/src/gig/typed_ast.gleam
+++ b/src/gig/typed_ast.gleam
@@ -2704,26 +2704,6 @@ pub fn resolve_type(c: Context, typ: Type) -> Type {
   }
 }
 
-pub fn resolve_type_deep(c: Context, typ: Type) {
-  case typ {
-    VariableType(x) -> {
-      case get_type_var(c, x) {
-        Bound(x) -> resolve_type_deep(c, x)
-        Unbound(..) -> typ
-      }
-    }
-    NamedType(name, mod, args) ->
-      NamedType(name, mod, list.map(args, resolve_type_deep(c, _)))
-    FunctionType(args, ret) ->
-      FunctionType(
-        list.map(args, resolve_type_deep(c, _)),
-        resolve_type_deep(c, ret),
-      )
-    TupleType(elements) ->
-      TupleType(list.map(elements, resolve_type_deep(c, _)))
-  }
-}
-
 fn substitute_custom_type(c: Context, custom_type: CustomType) {
   // TODO: do we need to substitute type annotations?
   CustomType(
@@ -3049,9 +3029,7 @@ fn substitute_type(c: Context, typ: Type) {
       TupleType(elements:)
     }
     VariableType(ref) -> {
-      let assert Ok(x) = dict.get(c.type_vars, ref)
-        as { "Not found " <> string.inspect(ref) }
-      case x {
+      case get_type_var(c, ref) {
         Bound(x) -> substitute_type(c, x)
         Unbound -> VariableType(ref)
       }

--- a/src/gig/typed_ast.gleam
+++ b/src/gig/typed_ast.gleam
@@ -375,7 +375,7 @@ pub fn new_context() -> Context {
     type_vars: dict.new(),
     modules: dict.new(),
     type_uid: 0,
-    temp_uid: 0,
+    temp_uid: 1,
     module_env: dict.new(),
     type_env: dict.new(),
     value_env: dict.new(),

--- a/src/gig/typed_ast.gleam
+++ b/src/gig/typed_ast.gleam
@@ -351,7 +351,6 @@ pub type QualifiedName {
 
 pub type Context {
   Context(
-    module_source: String,
     current_module: String,
     current_definition: String,
     current_span: Span,
@@ -370,7 +369,6 @@ pub type TypeEnv =
 
 pub fn new_context() -> Context {
   Context(
-    module_source: "",
     current_module: "",
     current_definition: "",
     current_span: Span(0, 0),
@@ -385,7 +383,6 @@ pub fn infer_module(
   c: Context,
   module: g.Module,
   module_name: String,
-  module_source: String,
 ) -> Result(Context, Error) {
   let modules =
     dict.insert(
@@ -404,7 +401,7 @@ pub fn infer_module(
       ),
     )
 
-  let c = Context(..c, modules:, current_module: module_name, module_source:)
+  let c = Context(..c, modules:, current_module: module_name)
 
   // handle module imports
   use c <- result.try(

--- a/src/gig/typed_ast.gleam
+++ b/src/gig/typed_ast.gleam
@@ -2710,18 +2710,23 @@ pub fn resolve_type(c: Context, typ: Type) -> Type {
 }
 
 fn substitute_custom_type(c: Context, custom_type: CustomType) {
-  // TODO: do we need to substitute type annotations?
   CustomType(
     ..custom_type,
     typ: substitute_poly(c, custom_type.typ),
     variants: list.map(custom_type.variants, fn(variant) {
-      Variant(..variant, typ: substitute_poly(c, variant.typ))
+      Variant(
+        ..variant,
+        typ: substitute_poly(c, variant.typ),
+        fields: list.map(
+          variant.fields,
+          map_field(_, substitute_annotation(c, _)),
+        ),
+      )
     }),
   )
 }
 
 fn substitute_function(c: Context, function: FunctionDefinition) {
-  // TODO: do we need to substitute type annotations?
   FunctionDefinition(
     ..function,
     typ: substitute_poly(c, function.typ),
@@ -2730,6 +2735,7 @@ fn substitute_function(c: Context, function: FunctionDefinition) {
       _,
     )),
     body: list.map(function.body, substitute_statement(c, _)),
+    return: option.map(function.return, substitute_annotation(c, _)),
   )
 }
 
@@ -2737,11 +2743,14 @@ fn substitute_function_parameter(
   c: Context,
   param: FunctionParameter,
 ) -> FunctionParameter {
-  FunctionParameter(..param, typ: substitute_type(c, param.typ))
+  FunctionParameter(
+    ..param,
+    typ: substitute_type(c, param.typ),
+    annotation: option.map(param.annotation, substitute_annotation(c, _)),
+  )
 }
 
 fn substitute_statement(c: Context, statement: Statement) -> Statement {
-  // TODO: do we need to substitute type annotations?
   case statement {
     Use(typ:, patterns:, function:) ->
       Use(
@@ -2754,7 +2763,7 @@ fn substitute_statement(c: Context, statement: Statement) -> Statement {
         typ: substitute_type(c, typ),
         kind:,
         pattern: substitute_pattern(c, pattern),
-        annotation:,
+        annotation: option.map(annotation, substitute_annotation(c, _)),
         value: substitute_expression(c, value),
       )
     Assert(typ:, expression:, message:) ->
@@ -2828,7 +2837,7 @@ fn substitute_expression(c: Context, expr: Expression) -> Expression {
       Fn(
         typ: substitute_type(c, typ),
         parameters: list.map(parameters, substitute_function_parameter(c, _)),
-        return:,
+        return: option.map(return, substitute_annotation(c, _)),
         body: list.map(body, substitute_statement(c, _)),
       )
     RecordUpdate(
@@ -3004,16 +3013,6 @@ fn substitute_pattern(c: Context, pattern: Pattern) -> Pattern {
   }
 }
 
-fn map_bit_string_segment_option(
-  option: BitStringSegmentOption(a),
-  func: fn(a) -> a,
-) -> BitStringSegmentOption(a) {
-  case option {
-    SizeValueOption(expr) -> SizeValueOption(func(expr))
-    _ -> option
-  }
-}
-
 fn substitute_poly(c: Context, poly: Poly) {
   Poly(poly.vars, substitute_type(c, poly.typ))
 }
@@ -3042,6 +3041,32 @@ fn substitute_type(c: Context, typ: Type) {
   }
 }
 
+fn substitute_annotation(c: Context, anno: Annotation) -> Annotation {
+  case anno {
+    NamedAnno(typ:, module:, name:, parameters:) ->
+      NamedAnno(
+        typ: substitute_type(c, typ),
+        module:,
+        name:,
+        parameters: list.map(parameters, substitute_annotation(c, _)),
+      )
+    TupleAnno(typ:, elements:) ->
+      TupleAnno(
+        typ: substitute_type(c, typ),
+        elements: list.map(elements, substitute_annotation(c, _)),
+      )
+    FunctionAnno(typ:, parameters:, return:) ->
+      FunctionAnno(
+        typ: substitute_type(c, typ),
+        parameters: list.map(parameters, substitute_annotation(c, _)),
+        return: substitute_annotation(c, return),
+      )
+    VariableAnno(typ:, name:) ->
+      VariableAnno(typ: substitute_type(c, typ), name:)
+    HoleAnno(typ:, name:) -> HoleAnno(substitute_type(c, typ), name:)
+  }
+}
+
 fn map_field(field: Field(a), func: fn(a) -> b) -> Field(b) {
   Field(..field, item: func(field.item))
 }
@@ -3052,4 +3077,14 @@ fn map_definition(def: Definition(a), func: fn(a) -> b) -> Definition(b) {
 
 fn location(c: Context) {
   Location(c.module.name, c.current_definition, c.current_span)
+}
+
+fn map_bit_string_segment_option(
+  option: BitStringSegmentOption(a),
+  func: fn(a) -> a,
+) -> BitStringSegmentOption(a) {
+  case option {
+    SizeValueOption(expr) -> SizeValueOption(func(expr))
+    _ -> option
+  }
 }


### PR DESCRIPTION
For issue #6.

This is a draft PR. The compiler is currently broken at codegen stage (something to do with tuples and/or closures) but is able to complete type inference, lowering, and monomorphization for itself. I will try to identify the issue later, but pointers are very welcome!

This implements your suggestion to move resolving type references into typed_ast, and core has been simplified as a result. I think there is probably a small performance penalty to the current implementation. Once it is full working I have additional refactoring in mind that should resolve this.

Resolving globals now cares whether they're public, so I had to update some of the patch files.